### PR TITLE
Fix delta time calculation

### DIFF
--- a/compare_drivers.py
+++ b/compare_drivers.py
@@ -42,7 +42,15 @@ speed1 = tel1_interp['Speed']
 speed2 = tel2_interp['Speed']
 
 # --- Delta computation ---
-delta = speed2.cumsum() - speed1.cumsum()
+# Convert speeds from km/h to m/s
+speed1_ms = speed1 / 3.6
+speed2_ms = speed2 / 3.6
+
+# Distance step for each sample (in meters)
+dist_step = np.gradient(common_distance)
+
+# Cumulative time delta in seconds (positive means driver2 is faster)
+delta = np.cumsum(dist_step * (1 / speed1_ms - 1 / speed2_ms))
 
 # --- Plot ---
 fig, axs = plt.subplots(2, 1, sharex=True, figsize=(10, 6))
@@ -55,11 +63,11 @@ axs[0].grid(True)
 axs[0].set_title(f'Speed Trace - {args.driver1.upper()} vs {args.driver2.upper()} - {args.track} {args.year} {args.session.upper()}')
 
 axs[1].plot(common_distance, delta, color='purple')
-axs[1].set_ylabel(f'Delta ({args.driver2.upper()} - {args.driver1.upper()})')
+axs[1].set_ylabel(f"Delta Time ({args.driver2.upper()} - {args.driver1.upper()}) [s]")
 axs[1].set_xlabel('Distance (m)')
 axs[1].axhline(0, color='gray', linestyle='--')
 axs[1].grid(True)
-axs[1].set_title('Cumulative Speed Delta')
+axs[1].set_title('Cumulative Time Delta')
 
 plt.tight_layout()
 plt.show()

--- a/fetch_data.py
+++ b/fetch_data.py
@@ -7,7 +7,8 @@ os.makedirs('./f1_cache', exist_ok=True)
 fastf1.Cache.enable_cache('./f1_cache')
 setup_mpl()
 
-session = fastf1.get_session(2020, 'Monaco', 'R')
+# Use an existing session to avoid fetch errors
+session = fastf1.get_session(2023, 'Monaco', 'Q')
 session.load()
 
 lap = session.laps.pick_driver('VER').pick_fastest()


### PR DESCRIPTION
## Summary
- use 2023 Monaco qualifying session for example data
- compute driver delta as cumulative time difference in `compare_drivers.py`

## Testing
- `python -m py_compile app.py compare_drivers.py fetch_data.py`

------
https://chatgpt.com/codex/tasks/task_e_6875c94251708321bfce146fc21ef591