### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🏎️ F1 Driver Comparison Tool
 
-An interactive Streamlit dashboard to visualize and compare the fastest laps between two Formula 1 drivers using real telemetry data. Built with FastF1, Plotly, and Streamlit, this app displays a broadcast-style map of speed dominance and a speed-over-distance trace. Experince it [here](https://f1-devanalysis.streamlit.app/).
+An interactive Streamlit dashboard to visualize and compare the fastest laps between two Formula 1 drivers using real telemetry data. Built with FastF1, Plotly, and Streamlit, this app displays a broadcast-style map of speed dominance and a speed-over-distance trace. Experience it [here](https://f1-devanalysis.streamlit.app/).
 
 ---
 


### PR DESCRIPTION
## Summary
- fix spelling of "Experience" in README

## Testing
- `grep -n Experience README.md`

------
https://chatgpt.com/codex/tasks/task_e_6875cba71d708321b51e069dedd0b0a1